### PR TITLE
support blocker condition based on next location

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Action, Location } from "history";
+import { Action, Location, Transition } from "history";
 
 import useBlocker from "./hooks/use-blocker";
 import useConfirm from "./hooks/use-confirm";
@@ -51,10 +51,10 @@ const ReactRouterPrompt: React.FC<ReactRouterPromptProps> = ({
   } = useConfirm(when);
 
   const blocker = useCallback(
-    // @ts-ignore
-    async tx => {
-      if (await onConfirm(tx)) {
-        resetConfirmation();
+    async (tx: Transition) => {
+      const result = await onConfirm(tx);
+      if (result) {
+        if (result !== "noReset") resetConfirmation();
         tx.retry();
       }
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,17 @@
 import React, { useCallback } from "react";
+import { Action, Location } from "history";
 
-import useConfirm from "./hooks/use-confirm";
 import useBlocker from "./hooks/use-blocker";
+import useConfirm from "./hooks/use-confirm";
 
-type ReactRouterPromptProps = {
-  when: boolean;
+export type ReactRouterPromptProps = {
+  when:
+    | boolean
+    | ((
+        currentLocation: Location,
+        nextLocation: Location,
+        _action: Action
+      ) => boolean);
   children: (data: {
     isActive: boolean;
     onCancel: (value: unknown) => void;
@@ -41,12 +48,12 @@ const ReactRouterPrompt: React.FC<ReactRouterPromptProps> = ({
     onConfirm,
     hasConfirmed,
     resetConfirmation,
-  } = useConfirm();
+  } = useConfirm(when);
 
   const blocker = useCallback(
     // @ts-ignore
     async tx => {
-      if (await onConfirm()) {
+      if (await onConfirm(tx)) {
         resetConfirmation();
         tx.retry();
       }


### PR DESCRIPTION
The prompt appears whenever anything about the location changes, but this is undesirable some cases.

For example, an app that stores some state in the URL search string may not want the prompt to appear when the search string is modified.

This change modifies the `when` prop to support a function `(currentLocation: Location, nextLocation: Locaiton, _action: Action) => boolean` that should return true when the navigation to `nextLocation` should be blocked and false when navigation to `nextLocation` should be allowed.

`when` can still be a boolean type, so this should not break existing conditions._
This also means that the `when` prop is now the same type as the `when` prop from react-router-navigation-prompt.

### Example code
It is almost the same as the example in the README, but in this case, the modal is only shown when the pathnames do not match.

```
<ReactRouterPrompt
  when={(currentLocation, nextLocation) => {
    return isDirty && currentLocation.pathname !== nextLocation.pathname;
  }}
>
  {({ isActive, onConfirm, onCancel }) => (
    <Modal show={isActive}>
      <div>
        <p>Do you really want to leave?</p>
        <button onClick={onCancel}>Cancel</button>
        <button onClick={onConfirm}>Ok</button>
      </div>
    </Modal>
  })
</ReactRouterPrompt>
```