### PR TITLE
fix(use-blocker): use history instance for block navigation

### DIFF
--- a/src/hooks/use-blocker.ts
+++ b/src/hooks/use-blocker.ts
@@ -1,16 +1,13 @@
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 import { Blocker, Transition } from "history";
-// @ts-ignore
-import { UNSAFE_NavigationContext as NavigationContext } from "react-router-dom";
+import history from "history/browser";
 
 function useBlocker(blocker: Blocker, when = true) {
-  const { navigator } = useContext(NavigationContext);
-
   useEffect(() => {
     if (!when) return;
 
     // @ts-ignore
-    const unblock = navigator.block((tx: Transition) => {
+    const unblock = history.block((tx: Transition) => {
       const autoUnblockingTx = {
         ...tx,
         retry() {
@@ -26,7 +23,7 @@ function useBlocker(blocker: Blocker, when = true) {
     });
 
     return unblock;
-  }, [navigator, blocker, when]);
+  }, [blocker, when]);
 }
 
 export default useBlocker;


### PR DESCRIPTION
remove NavigationContext not supported by react router >6.4 and use history instance provide by history library you can review doc here : https://github.com/remix-run/history/blob/dev/docs/blocking-transitions.md

fix #38