### PR TITLE
unstable_useBlocker -> useBlocker for react-router@6.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ### Prerequisite
 
-**React-router-dom >= 6.7** and can be used only with [**data routers**](https://reactrouter.com/en/6.8.1/routers/picking-a-router#using-v64-data-apis)
+**React-router-dom >= 6.19** and can be used only with [**data routers**](https://reactrouter.com/en/6.8.1/routers/picking-a-router#using-v64-data-apis)
 
 ```bash
 pnpm add react-router-prompt
@@ -69,7 +69,7 @@ yarn add react-router-prompt
 
 #### Note 🗒️
 
-This version works with react-router-dom >=v6.7
+This version works with react-router-dom >=v6.19
 Should be used within [data routers](https://reactrouter.com/en/6.8.1/routers/picking-a-router#using-v64-data-apis)
 
 For react-router-support `(v6 - v6.2.x)` please install v0.3.0

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "^6.19.0",
     "size-limit": "^8.1.2",
     "tslib": "^2.5.0",
     "typescript": "^5.0.0",
@@ -85,7 +85,7 @@
   "peerDependencies": {
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "react-router-dom": ">=6.7"
+    "react-router-dom": ">=6.19"
   },
   "size-limit": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ devDependencies:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
   react-router-dom:
-    specifier: ^6.8.1
-    version: 6.8.1(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^6.19.0
+    version: 6.19.0(react-dom@18.2.0)(react@18.2.0)
   size-limit:
     specifier: ^8.1.2
     version: 8.1.2
@@ -653,9 +653,9 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@remix-run/router@1.3.2:
-    resolution: {integrity: sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==}
-    engines: {node: '>=14'}
+  /@remix-run/router@1.12.0:
+    resolution: {integrity: sha512-2hXv036Bux90e1GXTWSMfNzfDDK8LA8JYEWfyHxzvwdp6GyoWEovKc9cotb3KCKmkdwsIBuFGX7ScTWyiHv7Eg==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /@rollup/pluginutils@5.0.2:
@@ -3045,26 +3045,26 @@ packages:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
-  /react-router-dom@6.8.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==}
-    engines: {node: '>=14'}
+  /react-router-dom@6.19.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-N6dWlcgL2w0U5HZUUqU2wlmOrSb3ighJmtQ438SWbhB1yuLTXQ8yyTBMK3BSvVjp7gBtKurT554nCtMOgxCZmQ==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.3.2
+      '@remix-run/router': 1.12.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.8.1(react@18.2.0)
+      react-router: 6.19.0(react@18.2.0)
     dev: true
 
-  /react-router@6.8.1(react@18.2.0):
-    resolution: {integrity: sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==}
-    engines: {node: '>=14'}
+  /react-router@6.19.0(react@18.2.0):
+    resolution: {integrity: sha512-0W63PKCZ7+OuQd7Tm+RbkI8kCLmn4GPjDbX61tWljPxWgqTKlEpeQUwPkT1DRjYhF8KSihK0hQpmhU4uxVMcdw==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.3.2
+      '@remix-run/router': 1.12.0
       react: 18.2.0
     dev: true
 

--- a/src/hooks/use-prompt.ts
+++ b/src/hooks/use-prompt.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from "react"
 import {
   useBeforeUnload,
-  unstable_useBlocker as useBlocker,
+  useBlocker,
   unstable_Blocker as Blocker,
   unstable_BlockerFunction as BlockerFunction,
 } from "react-router-dom"


### PR DESCRIPTION
Fix for rename of `unstable_useBlocker` to `useBlocker` in `react-router@6.19` as raised in https://github.com/sshyam-gupta/react-router-prompt/issues/123.