### PR TITLE
Fix ReactRouterPromptProps Type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,8 @@ type ReactRouterPromptProps = {
   when: boolean | BlockerFunction
   children: (data: {
     isActive: boolean
-    onCancel(): void
-    onConfirm(): void
+    onCancel: () => void
+    onConfirm: () => void
   }) => React.ReactNode
   beforeCancel?: () => Promise<unknown>
   beforeConfirm?: () => Promise<unknown>


### PR DESCRIPTION
Currently it causes the following error with eslint on typescript:

```
error  Avoid referencing unbound methods which may cause unintentional scoping of `this`.
If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead  @typescript-eslint/unbound-method
```