### PR TITLE
Remove `isActive` dependency when `ReactRouterPrompt`'s `children` returns.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,19 +53,16 @@ function ReactRouterPrompt({
     resetConfirmation()
   }, [beforeCancel, resetConfirmation])
 
-  if (isActive) {
-    return (
-      <>
-        {children({
-          isActive: true,
-          onConfirm: onConfirmAction,
-          onCancel: onResetAction,
-          nextLocation: nextLocation || undefined,
-        })}
-      </>
-    )
-  }
-  return null
+  return (
+    <>
+      {children({
+        isActive: true,
+        onConfirm: onConfirmAction,
+        onCancel: onResetAction,
+        nextLocation: nextLocation || undefined,
+      })}
+    </>
+  )
 }
 
 export { useConfirm, usePrompt }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,7 +56,7 @@ function ReactRouterPrompt({
   return (
     <>
       {children({
-        isActive: true,
+        isActive: isActive,
         onConfirm: onConfirmAction,
         onCancel: onResetAction,
         nextLocation: nextLocation || undefined,


### PR DESCRIPTION
It seems right to leave it up to the user's discretion to render or not based on `isActive`. If `isActive` is `false`, `children` is not returned at all.