### PR TITLE
Adding type again to make it discoverable in typescript projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/react-router-prompt.js",
-      "require": "./dist/react-router-prompt.umd.cjs"
+      "require": "./dist/react-router-prompt.umd.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "author": "Shyam Gupta (shyamm@outlook.com)",


### PR DESCRIPTION
 We have a react / TypeScript project with react-router-prompt 0.7.1.
 
After an update to version 0.8.1, we get the following build error message:
 
`There are types at '<My project path>/node_modules/react-router-prompt/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-router-prompt' library may need to update its package.json or typings.`
 
 It turns out that in version 0.7.1 package.json (547075213b61a55a8aa4ea5d83dabda4cfeaaec) had an additional entry to the exported type information. When adding this path manually in the node_modules/ of react-router-prompt folder, it works again.

So I assume, this path should be added again.

Thank you, Matthias